### PR TITLE
Update Custom Widgets Lambda runtime from nodejs12.x to nodejs16x

### DIFF
--- a/scripts/build-assets
+++ b/scripts/build-assets
@@ -34,7 +34,7 @@ for sampleDir in $SAMPLES_DIR/*/ ; do
 
         if [ $extension == 'js' ]; then
             handler="index.handler"
-            runtime="nodejs12.x"
+            runtime="nodejs16.x"
         else
             handler="index.lambda_handler"
             runtime="python3.7"       # python 3.8 doesn't suport inline zipfile yet


### PR DESCRIPTION
*Issue #, if available:*

- nodejs12.x will be deprecated on [Mar 31, 2023](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html).

*Description of changes:*

- Update Custom Widgets Lambda runtime from nodejs12.x to nodejs16x

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
