### PR TITLE
Update permissions.yaml to have variable partitions in the ARNs

### DIFF
--- a/samples/athenaQuery/permissions.yaml
+++ b/samples/athenaQuery/permissions.yaml
@@ -9,7 +9,7 @@
           - s3:ListMultipartUploadParts
           - s3:DeleteObject
           Resource:
-          - !Sub arn:aws:s3:::aws-cw-widget-athena-query-results-${AWS::AccountId}-${AWS::Region}/*
+          - !Sub arn:${AWS::Partition}:s3:::aws-cw-widget-athena-query-results-${AWS::AccountId}-${AWS::Region}/*
         - Effect: Allow
           Action:
           - s3:GetBucketLocation
@@ -18,7 +18,7 @@
           - s3:ListBucketMultipartUploads
           - s3:DeleteObject
           Resource:
-          - !Sub arn:aws:s3:::aws-cw-widget-athena-query-results-${AWS::AccountId}-${AWS::Region}
+          - !Sub arn:${AWS::Partition}:s3:::aws-cw-widget-athena-query-results-${AWS::AccountId}-${AWS::Region}
         - Effect: Allow
           Action:
           - athena:*


### PR DESCRIPTION
*Description of changes: The partitions for the athenaQuery were hardcoded. In order for the sample to work in any partition, this has to follow the existing pattern and use the CFN ${AWS::Partition} variable

