### PR TITLE
Update build-assets to upgrade the runtime for the python samples fro…

### DIFF
--- a/scripts/build-assets
+++ b/scripts/build-assets
@@ -37,7 +37,7 @@ for sampleDir in $SAMPLES_DIR/*/ ; do
             runtime="nodejs16.x"
         else
             handler="index.lambda_handler"
-            runtime="python3.7"       # python 3.8 doesn't suport inline zipfile yet
+            runtime="python3.12"
         fi
 
         # Create CloudFormation template


### PR DESCRIPTION
…m 3.7 to 3.12

As python3.7 has been deprecated from the supported runtimes on Lambda functions, the current CloudFormation Stacks fail creation. More on the runtime deprecation of python3.7 can be found in the dedicated documentation

*Issue #4 

*Description of changes:*
 upgrade the runtime for the python samples from 3.7 to 3.12

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
