### PR TITLE
downgrade the python runtime to 3.11

### DIFF
--- a/samples/cloudWatchBitmapGraph/cloudWatchBitmapGraph.py
+++ b/samples/cloudWatchBitmapGraph/cloudWatchBitmapGraph.py
@@ -8,7 +8,7 @@ import datetime
 import json
 import os
 
-DOCS = """
+DOCS = f"""
 ## Display a CloudWatch bitmap graph
 Displays CloudWatch metrics as a bitmap, for faster display of metrics.
 
@@ -23,7 +23,7 @@ graph:
   view: timeSeries
   metrics:
   - [ AWS/Lambda, Invocations ]
-  region: {os.environ("AWS_REGION")}
+  region: {os.environ.get("AWS_REGION")}
 ```"""
 
 def lambda_handler(event, context):

--- a/samples/rssReader/rssReader.py
+++ b/samples/rssReader/rssReader.py
@@ -22,7 +22,7 @@ Param | Description
 
 ### Example parameters
 ``` yaml
-url: http://status.aws.amazon.com/rss/cloudwatch-us-east-1.rss
+url: https://aws.amazon.com/blogs/aws/feed/
 entryTag: ./channel/item
 fields: [ title, pubDate, description ]
 ```"""

--- a/scripts/build-assets
+++ b/scripts/build-assets
@@ -37,7 +37,7 @@ for sampleDir in $SAMPLES_DIR/*/ ; do
             runtime="nodejs16.x"
         else
             handler="index.lambda_handler"
-            runtime="python3.12"
+            runtime="python3.11"
         fi
 
         # Create CloudFormation template


### PR DESCRIPTION
*Description of changes:*
As 3.12 is not supported as a runtime for Lambda functions across all regions and partitions we are downgrading it to 3.11

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
